### PR TITLE
Fix state constants to match schema and follow core quiz pattern

### DIFF
--- a/classes/groupquiz_attempt.php
+++ b/classes/groupquiz_attempt.php
@@ -44,10 +44,10 @@ DM20-0197
 class groupquiz_attempt {
 
     /** Constants for the status of the attempt */
-    const NOTSTARTED = 0;
-    const INPROGRESS = 10;
-    const ABANDONED = 20;
-    const FINISHED = 30;
+    const NOTSTARTED = 'notstarted';
+    const INPROGRESS = 'inprogress';
+    const ABANDONED = 'abandoned';
+    const FINISHED = 'finished';
 
     /** @var \stdClass The attempt record */
     protected $attempt;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -103,6 +103,18 @@ function xmldb_groupquiz_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2025112001, 'groupquiz');
     }
 
+    if ($oldversion < 2026060200) {
+        // Migrate state column from numeric values to string values to match core quiz pattern.
+        // Old: 0='notstarted', 10='inprogress', 20='abandoned', 30='finished'
+        // New: 'notstarted', 'inprogress', 'abandoned', 'finished'
+        $DB->execute("UPDATE {groupquiz_attempts} SET state = 'notstarted' WHERE state = '0'");
+        $DB->execute("UPDATE {groupquiz_attempts} SET state = 'inprogress' WHERE state = '10'");
+        $DB->execute("UPDATE {groupquiz_attempts} SET state = 'abandoned' WHERE state = '20'");
+        $DB->execute("UPDATE {groupquiz_attempts} SET state = 'finished' WHERE state = '30'");
+
+        upgrade_mod_savepoint(true, 2026060200, 'groupquiz');
+    }
+
     return true;
 }
 

--- a/version.php
+++ b/version.php
@@ -38,7 +38,7 @@ DM20-0197
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2026051201;
+$plugin->version = 2026060200;
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = 2022041901.10;  // Moodle '4.0.1+ (Build: 20220701)';


### PR DESCRIPTION
Changes state constants from integers to strings to properly match the char(16) state column in the database schema. This follows the pattern used by core mod/quiz rather than mod/activequiz.

The mismatch was causing PostgreSQL type errors when using get_in_or_equal() because PostgreSQL strictly enforces type matching and does not implicitly cast integers to varchar in IN clauses.

Changes:
- Change constants from integers (0, 10, 20, 30) to strings ('notstarted', 'inprogress', 'abandoned', 'finished') matching core quiz pattern
- Add upgrade migration to convert existing numeric state values to strings
- Bump version to 2026060200

This aligns with the fix applied to mod_topomojo. The schema was always char(16) with DEFAULT='inprogress' but the code incorrectly used numeric constants copied from mod/activequiz (which uses TYPE="int" for its status column).